### PR TITLE
Handle Pydantic generating allOf for enums with default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ print(json.dumps(schema_dict))
 
 ```
 #### Coerce type
-Pydantic-spark provides a `coerce_type` option that allows type coercion. 
-When applied to a field, pydantic-spark converts the column's data type to the specified coercion type. 
+Pydantic-spark provides a `coerce_type` option that allows type coercion.
+When applied to a field, pydantic-spark converts the column's data type to the specified coercion type.
 
 ```python
 import json
@@ -40,7 +40,7 @@ from pydantic import Field
 from pydantic_spark.base import SparkBase, CoerceType
 
 class TestModel(SparkBase):
-    key1: str = Field(extra_json_schema={"coerce_type": CoerceType.integer})
+    key1: str = Field(json_schema_extra={"coerce_type": CoerceType.integer})
 
 schema_dict: dict = TestModel.spark_schema()
 print(json.dumps(schema_dict))
@@ -62,7 +62,7 @@ poetry install
 ```shell
 pytest
 coverage run -m pytest  # with coverage
-# or (depends on your local env) 
+# or (depends on your local env)
 poetry run pytest
 poetry run coverage run -m pytest  # with coverage
 ```

--- a/tests/test_to_spark.py
+++ b/tests/test_to_spark.py
@@ -32,7 +32,7 @@ class NestedModel(SparkBase):
     c11: Nested2Model
 
 
-class TestModel(SparkBase):
+class ModelTest(SparkBase):
     c1: str
     c2: int
     c3: float
@@ -71,72 +71,67 @@ class DefaultValues(SparkBase):
 def test_spark():
     expected_schema = StructType(
         [
-            StructField("c1", StringType(), nullable=False, metadata={"parentClass": "TestModel"}),
-            StructField("c2", LongType(), nullable=False, metadata={"parentClass": "TestModel"}),
-            StructField("c3", DoubleType(), nullable=False, metadata={"parentClass": "TestModel"}),
-            StructField("c4", TimestampType(), nullable=False, metadata={"parentClass": "TestModel"}),
-            StructField("c5", DateType(), nullable=False, metadata={"parentClass": "TestModel"}),
-            StructField("c6", StringType(), nullable=True, metadata={"parentClass": "TestModel"}),
-            StructField("c7", BooleanType(), nullable=False, metadata={"parentClass": "TestModel"}),
             StructField(
-                "c8", StringType(), nullable=False, metadata={"logicalType": "uuid", "parentClass": "TestModel"}
+                "c1",
+                StringType(),
+                nullable=False,
+                metadata={"parentClass": "ModelTest"},
+            ),
+            StructField("c2", LongType(), nullable=False, metadata={"parentClass": "ModelTest"}),
+            StructField(
+                "c3",
+                DoubleType(),
+                nullable=False,
+                metadata={"parentClass": "ModelTest"},
             ),
             StructField(
-                "c9", StringType(), nullable=True, metadata={"logicalType": "uuid", "parentClass": "TestModel"}
+                "c4",
+                TimestampType(),
+                nullable=False,
+                metadata={"parentClass": "ModelTest"},
+            ),
+            StructField("c5", DateType(), nullable=False, metadata={"parentClass": "ModelTest"}),
+            StructField("c6", StringType(), nullable=True, metadata={"parentClass": "ModelTest"}),
+            StructField(
+                "c7",
+                BooleanType(),
+                nullable=False,
+                metadata={"parentClass": "ModelTest"},
             ),
             StructField(
-                "c10", MapType(StringType(), StringType()), nullable=False, metadata={"parentClass": "TestModel"}
+                "c8",
+                StringType(),
+                nullable=False,
+                metadata={"logicalType": "uuid", "parentClass": "ModelTest"},
             ),
             StructField(
-                "c11", MapType(StringType(), StringType()), nullable=False, metadata={"parentClass": "TestModel"}
+                "c9",
+                StringType(),
+                nullable=True,
+                metadata={"logicalType": "uuid", "parentClass": "ModelTest"},
+            ),
+            StructField(
+                "c10",
+                MapType(StringType(), StringType()),
+                nullable=False,
+                metadata={"parentClass": "ModelTest"},
+            ),
+            StructField(
+                "c11",
+                MapType(StringType(), StringType()),
+                nullable=False,
+                metadata={"parentClass": "ModelTest"},
             ),
         ]
     )
-    result = TestModel.spark_schema()
+    result = ModelTest.spark_schema()
     assert result == json.loads(expected_schema.json())
     # Reading schema with spark library to be sure format is correct
     schema = StructType.fromJson(result)
     assert len(schema.fields) == 11
 
 
-# def test_spark_write():
-#     record1 = TestModel(
-#         c1="1",
-#         c2=2,
-#         c3=3,
-#         c4=4,
-#         c5=5,
-#         c6=6,
-#         c7=7,
-#         c8=True,
-#         c9=uuid.uuid4(),
-#         c10=uuid.uuid4(),
-#         c11={"key": "value"},
-#         c12={},
-#     )
-#
-#     parsed_schema = parse_schema(TestModel.spark_schema())
-#
-#     # 'records' can be an iterable (including generator)
-#     records = [
-#         record1.dict(),
-#     ]
-#
-#     with tempfile.TemporaryDirectory() as dir:
-#         # Writing
-#         with open(os.path.join(dir, "test.spark"), "wb") as out:
-#             writer(out, parsed_schema, records)
-#
-#         result_records = []
-#         # Reading
-#         with open(os.path.join(dir, "test.spark"), "rb") as fo:
-#             for record in reader(fo):
-#                 result_records.append(TestModel.parse_obj(record))
-#     assert records == result_records
-
-
 def test_reused_object():
-
     expected_schema = StructType(
         [
             StructField(
@@ -187,7 +182,12 @@ def test_reused_object_array():
 def test_complex_spark():
     expected_schema = StructType(
         [
-            StructField("c1", ArrayType(StringType()), nullable=False, metadata={"parentClass": "ComplexTestModel"}),
+            StructField(
+                "c1",
+                ArrayType(StringType()),
+                nullable=False,
+                metadata={"parentClass": "ComplexTestModel"},
+            ),
             StructField(
                 "c2",
                 StructType.fromJson(NestedModel.spark_schema()),
@@ -200,7 +200,12 @@ def test_complex_spark():
                 nullable=False,
                 metadata={"parentClass": "ComplexTestModel"},
             ),
-            StructField("c4", ArrayType(TimestampType()), nullable=False, metadata={"parentClass": "ComplexTestModel"}),
+            StructField(
+                "c4",
+                ArrayType(TimestampType()),
+                nullable=False,
+                metadata={"parentClass": "ComplexTestModel"},
+            ),
             StructField(
                 "c5",
                 MapType(StringType(), StructType.fromJson(NestedModel.spark_schema())),
@@ -216,38 +221,16 @@ def test_complex_spark():
     assert len(schema.fields) == 5
 
 
-# def test_spark_write_complex():
-#     record1 = ComplexTestModel(
-#         c1=["1", "2"],
-#         c2=NestedModel(c11=Nested2Model(c111="test")),
-#         c3=[NestedModel(c11=Nested2Model(c111="test"))],
-#         c4=[1, 2, 3, 4],
-#         c5={"key": NestedModel(c11=Nested2Model(c111="test"))},
-#     )
-#
-#     parsed_schema = parse_schema(ComplexTestModel.spark_schema())
-#
-#     # 'records' can be an iterable (including generator)
-#     records = [
-#         record1.dict(),
-#     ]
-#
-#     with tempfile.TemporaryDirectory() as dir:
-#         # Writing
-#         with open(os.path.join(dir, "test.spark"), "wb") as out:
-#             writer(out, parsed_schema, records)
-#
-#         result_records = []
-#         # Reading
-#         with open(os.path.join(dir, "test.spark"), "rb") as fo:
-#             for record in reader(fo):
-#                 result_records.append(ComplexTestModel.parse_obj(record))
-#     assert records == result_records
-
-
 def test_defaults():
     expected_schema = StructType(
-        [StructField("c1", StringType(), nullable=False, metadata={"parentClass": "DefaultValues", "default": "test"})]
+        [
+            StructField(
+                "c1",
+                StringType(),
+                nullable=False,
+                metadata={"parentClass": "DefaultValues", "default": "test"},
+            )
+        ]
     )
     result = DefaultValues.spark_schema()
     assert result == json.loads(expected_schema.json())
@@ -271,21 +254,28 @@ class FloatEnumValue(float, Enum):
     v2 = 2.2
 
 
-class TestEnum(SparkBase):
+class EnumTest(SparkBase):
     c1: StringEnumValue
     c2: IntEnumValue
     c3: FloatEnumValue
+    c4: StringEnumValue = Field(default=StringEnumValue.v1)
 
 
 def test_enum():
     expected_schema = StructType(
         [
-            StructField("c1", StringType(), nullable=False, metadata={"parentClass": "TestEnum"}),
-            StructField("c2", LongType(), nullable=False, metadata={"parentClass": "TestEnum"}),
-            StructField("c3", DoubleType(), nullable=False, metadata={"parentClass": "TestEnum"}),
+            StructField("c1", StringType(), nullable=False, metadata={"parentClass": "EnumTest"}),
+            StructField("c2", LongType(), nullable=False, metadata={"parentClass": "EnumTest"}),
+            StructField("c3", DoubleType(), nullable=False, metadata={"parentClass": "EnumTest"}),
+            StructField(
+                "c4",
+                StringType(),
+                nullable=False,
+                metadata={"parentClass": "EnumTest", "default": StringEnumValue.v1},
+            ),
         ]
     )
-    result = TestEnum.spark_schema()
+    result = EnumTest.spark_schema()
     assert result == json.loads(expected_schema.json())
 
 
@@ -327,4 +317,7 @@ def test_coerce_type_complex_spark():
     # Reading schema with spark library to be sure format is correct
     schema = StructType.fromJson(result)
     assert len(schema.fields) == 1
-    assert isinstance(schema.fields[0].dataType.elementType.fields[0].dataType.fields[0].dataType, IntegerType)
+    assert isinstance(
+        schema.fields[0].dataType.elementType.fields[0].dataType.fields[0].dataType,
+        IntegerType,
+    )


### PR DESCRIPTION
See https://github.com/pydantic/pydantic/issues/2592 for a description of the issue. 
This only handles the case where allOf is a list of length 1 with a `$ref`. Additionally some warnings were fixed related to deprecated Pydantic V2 methods and pytest warnings on class names starting with `Test`.