### PR TITLE
Add support for optional objects in lists + Add support for optional lists of (optional) objects

### DIFF
--- a/src/pydantic_spark/base.py
+++ b/src/pydantic_spark/base.py
@@ -89,7 +89,7 @@ class SparkBase(BaseModel):
             if "default" in value:
                 metadata["default"] = value.get("default")
             if r is not None:
-                class_name = r.replace("#/definitions/", "")
+                class_name = r.replace("#/$defs/", "")
                 if class_name in classes_seen:
                     spark_type = classes_seen[class_name]
                 else:
@@ -138,7 +138,6 @@ class SparkBase(BaseModel):
                     f"Type '{t}' not support yet, "
                     f"please report this at https://github.com/godatadriven/pydantic-avro/issues"
                 )
-            print(spark_type)
             return spark_type, metadata
 
         def get_fields(s: dict) -> List[dict]:

--- a/src/pydantic_spark/base.py
+++ b/src/pydantic_spark/base.py
@@ -77,8 +77,7 @@ class SparkBase(BaseModel):
 
                     # if the type is an array and (has optional items),
                     # we will remove the null type and get the items
-                    if items is None:
-                        items = ao[0].get("items") if ao[0].get("type") != "null" else ao[1].get("items")
+                    items = ao[0].get("items") if ao[0].get("type") != "null" else ao[1].get("items")
 
                     # if the optional type is a ref, we will call get_type_of_definition
                     # this will recursively resolve the types of the ref object

--- a/src/pydantic_spark/base.py
+++ b/src/pydantic_spark/base.py
@@ -77,7 +77,8 @@ class SparkBase(BaseModel):
 
                     # if the type is an array and (has optional items),
                     # we will remove the null type and get the items
-                    items = ao[0].get("items") if ao[0].get("type") != "null" else ao[1].get("items")
+                    if not items:
+                        items = ao[0].get("items") if ao[0].get("type") != "null" else ao[1].get("items")
 
                     # if the optional type is a ref, we will prioritize it and call get_type_of_definition
                     # this will recursively resolve the types of the ref object
@@ -137,6 +138,7 @@ class SparkBase(BaseModel):
                     f"Type '{t}' not support yet, "
                     f"please report this at https://github.com/godatadriven/pydantic-avro/issues"
                 )
+            print(spark_type)
             return spark_type, metadata
 
         def get_fields(s: dict) -> List[dict]:

--- a/src/pydantic_spark/base.py
+++ b/src/pydantic_spark/base.py
@@ -77,7 +77,7 @@ class SparkBase(BaseModel):
 
                     # if the type is an array and (has optional items),
                     # we will remove the null type and get the items
-                    if not items:
+                    if items is None:
                         items = ao[0].get("items") if ao[0].get("type") != "null" else ao[1].get("items")
 
                     # if the optional type is a ref, we will prioritize it and call get_type_of_definition

--- a/src/pydantic_spark/base.py
+++ b/src/pydantic_spark/base.py
@@ -75,7 +75,8 @@ class SparkBase(BaseModel):
                     t = ao[0].get("type") if ao[0].get("type") != "null" else ao[1].get("type")
                     f = ao[0].get("format") if ao[0].get("type") != "null" else ao[1].get("format")
 
-                    # if the type is an array (has items), we will remove the null type and get the items
+                    # if the type is an array and (has optional items),
+                    # we will remove the null type and get the items
                     items = ao[0].get("items") if ao[0].get("type") != "null" else ao[1].get("items")
 
                     # if the optional type is a ref, we will prioritize it and call get_type_of_definition

--- a/src/pydantic_spark/base.py
+++ b/src/pydantic_spark/base.py
@@ -80,9 +80,9 @@ class SparkBase(BaseModel):
                     if items is None:
                         items = ao[0].get("items") if ao[0].get("type") != "null" else ao[1].get("items")
 
-                    # if the optional type is a ref, we will prioritize it and call get_type_of_definition
+                    # if the optional type is a ref, we will call get_type_of_definition
                     # this will recursively resolve the types of the ref object
-                    r = ao[0].get("$ref") if ao[0].get("$ref") is not None else ao[1].get("$ref")
+                    r = ao[0].get("$ref") if ao[0].get("type") != "null" else ao[1].get("$ref")
                 else:
                     NotImplementedError(f"Union type {ao} is not supported yet. Use coerce_type option to specify type")
 

--- a/src/pydantic_spark/base.py
+++ b/src/pydantic_spark/base.py
@@ -63,6 +63,7 @@ class SparkBase(BaseModel):
             r = value.get("$ref")
             a = value.get("additionalProperties")
             ft = value.get("coerce_type")
+            items = value.get("items")
             metadata = {}
 
             if ft is not None:
@@ -73,6 +74,9 @@ class SparkBase(BaseModel):
                     # this is an optional column. We will remove the null type
                     t = ao[0].get("type") if ao[0].get("type") != "null" else ao[1].get("type")
                     f = ao[0].get("format") if ao[0].get("type") != "null" else ao[1].get("format")
+
+                    # if the type is an array (has items), we will remove the null type and get the items
+                    items = ao[0].get("items") if ao[0].get("type") != "null" else ao[1].get("items")
 
                     # if the optional type is a ref, we will prioritize it and call get_type_of_definition
                     # this will recursively resolve the types of the ref object
@@ -90,17 +94,6 @@ class SparkBase(BaseModel):
                     spark_type = get_type_of_definition(r, schema)
                     classes_seen[class_name] = spark_type
             elif t == "array":
-                items = value.get("items")
-
-                # if the type of the field is an array and the array elements are optional
-                if not items and ao:
-                    if len(ao) == 2 and (ao[0].get("type") == "null" or ao[1].get("type") == "null"):
-                        items = ao[0].get("items") if ao[0].get("type") != "null" else ao[1].get("items")
-                    else:
-                        NotImplementedError(
-                            f"Union type {ao} is not supported yet." f" Use coerce_type option to specify type"
-                        )
-
                 tn, metadata = get_type(items)
                 spark_type = {
                     "type": "array",

--- a/src/pydantic_spark/base.py
+++ b/src/pydantic_spark/base.py
@@ -73,6 +73,10 @@ class SparkBase(BaseModel):
                     # this is an optional column. We will remove the null type
                     t = ao[0].get("type") if ao[0].get("type") != "null" else ao[1].get("type")
                     f = ao[0].get("format") if ao[0].get("type") != "null" else ao[1].get("format")
+
+                    # if the optional type is a ref, we will prioritize it and call get_type_of_definition
+                    # this will recursively resolve the types of the ref object
+                    r = ao[0].get("$ref") if ao[0].get("$ref") is not None else ao[1].get("$ref")
                 else:
                     NotImplementedError(f"Union type {ao} is not supported yet. Use coerce_type option to specify type")
 
@@ -87,6 +91,16 @@ class SparkBase(BaseModel):
                     classes_seen[class_name] = spark_type
             elif t == "array":
                 items = value.get("items")
+
+                # if the type of the field is an array and the array elements are optional
+                if not items and ao:
+                    if len(ao) == 2 and (ao[0].get("type") == "null" or ao[1].get("type") == "null"):
+                        items = ao[0].get("items") if ao[0].get("type") != "null" else ao[1].get("items")
+                    else:
+                        NotImplementedError(
+                            f"Union type {ao} is not supported yet." f" Use coerce_type option to specify type"
+                        )
+
                 tn, metadata = get_type(items)
                 spark_type = {
                     "type": "array",

--- a/tests/test_to_spark.py
+++ b/tests/test_to_spark.py
@@ -64,6 +64,14 @@ class ReusedObjectArray(SparkBase):
     c2: Nested2Model
 
 
+class OptionalObjectsInArray(SparkBase):
+    c1: List[Optional[Nested2Model]]
+
+
+class OptionalArrayOfArraysWithOptionalObjectsInArray(SparkBase):
+    c1: Optional[List[OptionalObjectsInArray]]
+
+
 class DefaultValues(SparkBase):
     c1: str = "test"
 
@@ -136,7 +144,6 @@ def test_spark():
 
 
 def test_reused_object():
-
     expected_schema = StructType(
         [
             StructField(
@@ -214,6 +221,43 @@ def test_complex_spark():
     # Reading schema with spark library to be sure format is correct
     schema = StructType.fromJson(result)
     assert len(schema.fields) == 5
+
+
+def test_optional_objects_in_array():
+    expected_schema = StructType(
+        [
+            StructField(
+                "c1",
+                ArrayType(elementType=StructType.fromJson(Nested2Model.spark_schema()), containsNull=True),
+                nullable=False,
+                metadata={"parentClass": "OptionalObjectsInArray"},
+            )
+        ]
+    )
+
+    result = OptionalObjectsInArray.spark_schema()
+    assert result == json.loads(expected_schema.json())
+    schema = StructType.fromJson(result)
+    assert len(schema.fields) == 1
+
+
+def test_optional_array_of_arrays_with_optional_objects_in_array():
+    expected_schema = StructType(
+        [
+            StructField(
+                "c1",
+                ArrayType(elementType=StructType.fromJson(OptionalObjectsInArray.spark_schema()), containsNull=True),
+                nullable=True,
+                metadata={"parentClass": "OptionalArrayOfArraysWithOptionalObjectsInArray"},
+            )
+        ]
+    )
+
+    result = OptionalArrayOfArraysWithOptionalObjectsInArray.spark_schema()
+
+    assert result == json.loads(expected_schema.json())
+    schema = StructType.fromJson(result)
+    assert len(schema.fields) == 1
 
 
 # def test_spark_write_complex():


### PR DESCRIPTION
**Adds support for optional objects in lists & Add support for optional lists of (optional) objects**

1. Generating the spark schema for array columns that contain optional objects used to result in errors.

The script would try to get the items for array types but if you have an array with optional object elements it would result in a `NotImplementedError` since the type and ref would be None. The ref would reside in `anyOf` which would contain `$ref`

```python
class OptionalObjectsInArray(SparkBase):
    c1: List[Optional[Nested2Model]]

OptionalObjectsInArray.spark_schema()
> `NotImplementedError`
```

2. Generating the spark schema for optional array columns that contain (optional) objects used to result in an Attribute error, since the array field would not have the attribute `items` it would have the attribute `anyOf` which would contain `items`

```python
class OptionalArrayOfArraysWithOptionalObjectsInArray(SparkBase):
    c1: Optional[List[OptionalObjectsInArray]]

OptionalArrayOfArraysWithOptionalObjectsInArray.spark_schema()
> `AttributeError: 'NoneType' object has no attribute 'get'`
```
